### PR TITLE
Prepare polymorph home

### DIFF
--- a/polymorph/UI/interface.py
+++ b/polymorph/UI/interface.py
@@ -21,16 +21,7 @@ class Interface(object):
 
     def __init__(self):
         self._poisoner = None
-        self._polym_path = os.path.expanduser("~/.polymorph")
-
-        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
-        # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
-        # Iterate all paths down the "~/.polymorph" to initialize it if needed
-        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
-        for _path in _conditions_path:
-            _full_path = "{}/{}".format(self._polym_path, _path)
-            if not os.path.exists(_full_path):
-                os.makedirs(_full_path)
+        self._polym_path = polymorph.settings.path
 
     @staticmethod
     def print_help(hdict):

--- a/polymorph/UI/interface.py
+++ b/polymorph/UI/interface.py
@@ -11,7 +11,7 @@ from polymorph.utils import get_arpspoofer
 from polymorph.UI.command_parser import CommandParser
 from collections import OrderedDict
 import os
-from os.path import dirname
+# from os.path import dirname
 import polymorph
 
 
@@ -21,7 +21,16 @@ class Interface(object):
 
     def __init__(self):
         self._poisoner = None
-        self._polym_path = dirname(polymorph.__file__)
+        self._polym_path = os.path.expanduser("~/.polymorph")
+
+        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
+        # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
+        # Iterate all paths down the "~/.polymorph" to initialize it if needed
+        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
+        for _path in _conditions_path:
+            _full_path = "{}/{}".format(self._polym_path, _path)
+            if not os.path.exists(_full_path):
+                os.makedirs(_full_path)
 
     @staticmethod
     def print_help(hdict):

--- a/polymorph/__init__.py
+++ b/polymorph/__init__.py
@@ -1,1 +1,4 @@
+from .settings import Settings
 
+# PoC to create initial settings manager
+settings = Settings()

--- a/polymorph/settings.py
+++ b/polymorph/settings.py
@@ -1,0 +1,16 @@
+import os
+
+class Settings (object):
+
+    def __init__(self):
+        self._poisoner = None
+        self.path = os.path.expanduser("~/.polymorph")
+
+        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
+        # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
+        # Iterate all paths down the "~/.polymorph" to initialize it if needed
+        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
+        for _path in _conditions_path:
+            _full_path = "{}/{}".format(self.path, _path)
+            if not os.path.exists(_full_path):
+                os.makedirs(_full_path)


### PR DESCRIPTION
# Preparing polymorph home

Just a PoC about how to deal with polymorph paths

By default this points to `~/.polymorph`, and at init time it ensures that the needed structure exists

In this case, we validate:
```
- ~/.polymorph
- ~/.polymorph/conditions
- ~/.polymorph/conditions/executions
- ~/.polymorph/conditions/postconditions
- ~/.polymorph/conditions/preconditions
