### PR TITLE
Use ~/polymorph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/*g
 *~
 .DS_Store
+*.egg-info

--- a/polymorph/UI/interface.py
+++ b/polymorph/UI/interface.py
@@ -21,16 +21,7 @@ class Interface(object):
 
     def __init__(self):
         self._poisoner = None
-        self._polym_path = os.path.expanduser("~/.polymorph")
-
-        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
-        # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
-        # Iterate all paths down the "~/.polymorph" to initialize it if needed
-        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
-        for _path in _conditions_path:
-            _full_path = "{}/{}".format(self._polym_path, _path)
-            if not os.path.exists(_full_path):
-                os.makedirs(_full_path)
+        self._polym_path = polymorph.settings.path
 
     @staticmethod
     def print_help(hdict):

--- a/polymorph/UI/interface.py
+++ b/polymorph/UI/interface.py
@@ -11,7 +11,7 @@ from polymorph.utils import get_arpspoofer
 from polymorph.UI.command_parser import CommandParser
 from collections import OrderedDict
 import os
-from os.path import dirname
+# from os.path import dirname
 import polymorph
 
 
@@ -21,7 +21,16 @@ class Interface(object):
 
     def __init__(self):
         self._poisoner = None
-        self._polym_path = dirname(polymorph.__file__)
+        self._polym_path = os.path.expanduser("~/.polymorph")
+
+        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
+        # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
+        # Iterate all paths down the "~/.polymorph" to initialize it if needed
+        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
+        for _path in _conditions_path:
+            _full_path = "{}/{}".format(self._polym_path, _path)
+            if not os.path.exists(_full_path):
+                os.makedirs(_full_path)
 
     @staticmethod
     def print_help(hdict):

--- a/polymorph/UI/templateinterface.py
+++ b/polymorph/UI/templateinterface.py
@@ -300,7 +300,7 @@ class TemplateInterface(Interface):
     def _create_cond(self, cond, name):
         """Creates a new condition with the initial source code."""
         code = "def %s(packet):\n\n    # your code here\n\n    # If the condition is meet\n    return packet" % name
-        with open("%s.py" % join(self._conds_path, cond, name), 'w') as f:
+        with open("%s.py" % join(settings.paths[cond], name), 'w') as f:
             f.write(code)
 
     def _add_cond(self, cond, name):

--- a/polymorph/UI/templateinterface.py
+++ b/polymorph/UI/templateinterface.py
@@ -305,9 +305,7 @@ class TemplateInterface(Interface):
 
     def _add_cond(self, cond, name):
         """Adds a new condition to the `Template`."""
-        m = importlib.import_module(
-            "polymorph.conditions.%s.%s" % (cond, name))
-        importlib.reload(m)
+        m = utils.import_file(join(settings.paths[cond], "{}.py".format(name)), "polymorph.conditions.%s.%s" % (cond, name))
         self._t.add_function(cond, name, getattr(m, dir(m)[-1]))
 
     @staticmethod

--- a/polymorph/UI/templateinterface.py
+++ b/polymorph/UI/templateinterface.py
@@ -46,8 +46,7 @@ class TemplateInterface(Interface):
         self._t = template
         self._index = index
         self._poisoner = poisoner
-        # TODO use any kind of condtions path defintion instead of hardcode it
-        self._conds_path = "{}/conditions".format(settings.path)
+        self._conds_path = settings.paths['conditions']
 
     def run(self):
         """Runs the interface and waits for user input commands."""

--- a/polymorph/UI/templateinterface.py
+++ b/polymorph/UI/templateinterface.py
@@ -21,7 +21,7 @@ import importlib
 import polymorph.conditions
 import platform
 from shutil import copyfile
-from polymorph import settings
+from polymorph import settings, utils
 
 class TemplateInterface(Interface):
     """This class is responsible for parsing and respond to user commands in
@@ -256,10 +256,10 @@ class TemplateInterface(Interface):
             # Adds a condition
             elif args['-a']:
                 # Create the new file if not exists
-                if not os.path.isfile(join(self._conds_path, cond, args["-a"] + ".py")):
+                if not os.path.isfile(join(self._conds_path, settings.paths[cond], args["-a"] + ".py")):
                     self._create_cond(cond, args["-a"])
                 ret = os.system("%s %s.py" % (
-                    args["-e"], join(self._conds_path, cond, args["-a"])))
+                    args["-e"], join(self._conds_path, settings.paths[cond], args["-a"])))
                 if ret != 0:
                     Interface._print_error(
                         "The editor is not installed or is not in the PATH")
@@ -288,6 +288,7 @@ class TemplateInterface(Interface):
                         name = file
                 if name[-3:] == ".py":
                     name = name[:-3]
+                self._add_cond(cond, name)
                 try:
                     self._add_cond(cond, name)
                     Interface._print_info("Condition %s imported" % args['-i'])

--- a/polymorph/UI/templateinterface.py
+++ b/polymorph/UI/templateinterface.py
@@ -21,7 +21,7 @@ import importlib
 import polymorph.conditions
 import platform
 from shutil import copyfile
-
+from polymorph import settings
 
 class TemplateInterface(Interface):
     """This class is responsible for parsing and respond to user commands in
@@ -46,7 +46,8 @@ class TemplateInterface(Interface):
         self._t = template
         self._index = index
         self._poisoner = poisoner
-        self._conds_path = dirname(polymorph.conditions.__file__)
+        # TODO use any kind of condtions path defintion instead of hardcode it
+        self._conds_path = "{}/conditions".format(settings.path)
 
     def run(self):
         """Runs the interface and waits for user input commands."""

--- a/polymorph/UI/templateinterface.py
+++ b/polymorph/UI/templateinterface.py
@@ -80,11 +80,11 @@ class TemplateInterface(Interface):
             elif command[0] in ["layer", "l"]:
                 self._layer(command)
             elif command[0] in ['precs', 'preconditions']:
-                self._conditions(command, 'preconditions')
+                self._conditions(command, settings.paths['preconditions'])
             elif command[0] in ['posts', 'postconditions']:
-                self._conditions(command, 'postconditions')
+                self._conditions(command, settings.paths['postconditions'])
             elif command[0] in ['execs', 'executions']:
-                self._conditions(command, 'executions')
+                self._conditions(command, settings.paths['executions'])
             elif command[0] in ["show", "s"]:
                 self._show(command)
             elif command[0] in ["intercept", "i"]:

--- a/polymorph/UI/templateinterface.py
+++ b/polymorph/UI/templateinterface.py
@@ -80,11 +80,11 @@ class TemplateInterface(Interface):
             elif command[0] in ["layer", "l"]:
                 self._layer(command)
             elif command[0] in ['precs', 'preconditions']:
-                self._conditions(command, settings.paths['preconditions'])
+                self._conditions(command, 'preconditions')
             elif command[0] in ['posts', 'postconditions']:
-                self._conditions(command, settings.paths['postconditions'])
+                self._conditions(command, 'postconditions')
             elif command[0] in ['execs', 'executions']:
-                self._conditions(command, settings.paths['executions'])
+                self._conditions(command, 'executions')
             elif command[0] in ["show", "s"]:
                 self._show(command)
             elif command[0] in ["intercept", "i"]:

--- a/polymorph/UI/tlistinterface.py
+++ b/polymorph/UI/tlistinterface.py
@@ -14,7 +14,7 @@ from polymorph.deps.prompt_toolkit.completion import WordCompleter
 from polymorph.deps.prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from polymorph.deps.prompt_toolkit.shortcuts import CompleteStyle
 import polymorph
-from os.path import dirname, join
+from os.path import join
 
 
 class TListInterface(Interface):
@@ -37,7 +37,7 @@ class TListInterface(Interface):
         # Class Attributes
         self._t = tlist
         self._poisoner = poisoner
-        self._polym_path = dirname(polymorph.__file__)
+        self._polym_path = polymorph.settings.path
 
     def run(self):
         """Runs the interface and waits for user input commands."""

--- a/polymorph/__init__.py
+++ b/polymorph/__init__.py
@@ -1,1 +1,4 @@
+from .settings import Settings
 
+# PoC to create initial settings manager
+settings = Settings()

--- a/polymorph/settings.py
+++ b/polymorph/settings.py
@@ -6,11 +6,16 @@ class Settings (object):
         self._poisoner = None
         self.path = os.path.expanduser("~/.polymorph")
 
-        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
+        self.paths = {
+            "": self.path,
+            "conditions": "{}/conditions".format(self.path),
+            "preconditions": "{}/conditions/preconditions".format(self.path),
+            "postconditions": "{}/conditions/postconditions".format(self.path),
+            "executions": "{}/conditions/executions".format(self.path),
+        }
+
         # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
-        # Iterate all paths down the "~/.polymorph" to initialize it if needed
-        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
-        for _path in _conditions_path:
+        for _path in self.paths.values():
             _full_path = "{}/{}".format(self.path, _path)
             if not os.path.exists(_full_path):
                 os.makedirs(_full_path)

--- a/polymorph/settings.py
+++ b/polymorph/settings.py
@@ -1,0 +1,16 @@
+import os
+
+class Settings (object):
+
+    def __init__(self):
+        self._poisoner = None
+        self.path = os.path.expanduser("~/.polymorph")
+
+        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
+        # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
+        # Iterate all paths down the "~/.polymorph" to initialize it if needed
+        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
+        for _path in _conditions_path:
+            _full_path = "{}/{}".format(self.path, _path)
+            if not os.path.exists(_full_path):
+                os.makedirs(_full_path)

--- a/polymorph/settings.py
+++ b/polymorph/settings.py
@@ -12,10 +12,10 @@ class Settings (object):
             "preconditions": "{}/conditions/preconditions".format(self.path),
             "postconditions": "{}/conditions/postconditions".format(self.path),
             "executions": "{}/conditions/executions".format(self.path),
+            "templates": "{}/templates".format(self.path),
         }
 
         # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
         for _path in self.paths.values():
-            _full_path = "{}/{}".format(self.path, _path)
-            if not os.path.exists(_full_path):
-                os.makedirs(_full_path)
+            if not os.path.exists(_path):
+                os.makedirs(_path)

--- a/polymorph/template.py
+++ b/polymorph/template.py
@@ -68,6 +68,9 @@ class Template:
         if not path:
             path = "../templates/" + self._name.replace("/", "_") + ".json"
 
+        if not path.endswith(".json"):
+            path += ".json"
+
         template_file = "{}/{}".format(settings.paths['templates'], path)
 
         with open(template_file, 'w') as outfile:

--- a/polymorph/template.py
+++ b/polymorph/template.py
@@ -219,7 +219,7 @@ class Template:
         """
         self.del_function('executions', name)
 
-    def get_function_source(self, func, name):
+    def get_function_source(self, cond, name):
         """Returns a precondition/postcondition/execution source code.
 
         Parameters
@@ -235,7 +235,7 @@ class Template:
             Source code of the function.
 
         """
-        path = "%s/%s/%s.py" % (self._conds_path, func, name)
+        path = join(settings.paths[cond], "{}.py".format(name))
         if os.path.isfile(path):
             return open(path).read()
         return "[!] File is not in disk"
@@ -588,6 +588,7 @@ class Template:
             print(colored(n, 'cyan'))
             print(self.get_function_source(cond, n))
 
+        _cond_path = settings.paths[cond]
         cond_names = list(self._functions[cond])
         if name and name in cond_names and verbose:
             print_source(cond, name)

--- a/polymorph/template.py
+++ b/polymorph/template.py
@@ -67,7 +67,10 @@ class Template:
         """
         if not path:
             path = "../templates/" + self._name.replace("/", "_") + ".json"
-        with open(path, 'w') as outfile:
+
+        template_file = "{}/{}".format(settings.paths['templates'], path)
+
+        with open(template_file, 'w') as outfile:
             json.dump(self.dict(), outfile, indent=4)
 
     @property

--- a/polymorph/template.py
+++ b/polymorph/template.py
@@ -612,9 +612,10 @@ class Template:
             conditions.
 
         """
+        _cond_path = settings.paths[cond]
         cond_names = [f[:-3]
-                      for f in listdir(join(self._conds_path, cond))
-                      if isfile(join(join(self._conds_path, cond), f))
+                      for f in listdir(_cond_path)
+                      if isfile(join(_cond_path, f))
                       and f != "__init__.py"
                       and f[-3:] == ".py"]
         if verbose:

--- a/polymorph/template.py
+++ b/polymorph/template.py
@@ -16,7 +16,7 @@ from os.path import dirname
 import polymorph.conditions
 from os import listdir
 from os.path import isfile, join
-
+from polymorph import settings
 
 class Template:
     """Main class that represents a template"""
@@ -47,7 +47,7 @@ class Template:
         if from_path:
             self.read(from_path)
         # Path to conditions (precs, execs, posts)
-        self._conds_path = dirname(polymorph.conditions.__file__)
+        self._conds_path = dirname(settings.paths['conditions'])
 
     def __repr__(self):
         return "<template.Template: %s>" % "/".join(self.layernames())
@@ -581,7 +581,7 @@ class Template:
         def print_source(cond, n):
             print(colored(n, 'cyan'))
             print(self.get_function_source(cond, n))
-            
+
         cond_names = list(self._functions[cond])
         if name and name in cond_names and verbose:
             print_source(cond, name)

--- a/polymorph/utils.py
+++ b/polymorph/utils.py
@@ -13,8 +13,41 @@ from polymorph.interceptor import Interceptor
 import platform
 import polymorph
 from os.path import dirname, join
+import imp, os, importlib
 
 POLYM_PATH = dirname(polymorph.__file__)
+
+
+def import_file(filename, module=""):
+    """
+    old stuff just for debug purposes
+    # m = importlib.import_module(
+    #     "polymorph.conditions.%s.%s" % (settings.paths[cond], name))
+    # importlib.reload(m)
+
+    """
+    module = None
+
+    try:
+        # Get module name and path from full path
+        module_dir, module_file = os.path.split(filename)
+        module_name, module_ext = os.path.splitext(module_file)
+
+        # Get module "spec" from filename
+        spec = importlib.util.spec_from_file_location(module_name,filename)
+
+        module = spec.loader.load_module()
+
+    except Exception as ec:
+        # TODO validate py2 importing if needed @shramos
+        print(ec)
+
+    finally:
+        return module
+
+    with open(filename, "r") as f:
+        return imp.load_module(module, f, filename, "")
+
 
 def capture(userfilter="", pcapname=".tmp.pcap", func=None, count=0, time=None):
     """This function is a wrapper function above the sniff scapy function. The
@@ -144,7 +177,7 @@ def set_ip_forwarding(value):
             file.write(str(value))
             file.close()
 
-        
+
 def get_arpspoofer(targets, gateway, iface=None, gatewaymac=None,
           ignore=None, arpmode='rep', mac=None, ip=None):
     # Creating a poison object
@@ -154,4 +187,3 @@ def get_arpspoofer(targets, gateway, iface=None, gatewaymac=None,
     poisoner = ARPpoisoner(poison)
     # return the poisoner
     return poisoner
-


### PR DESCRIPTION
# Use ~/.polymorph dir

This improves Polymorph to be able to store all files (conditions, templates, temps, ...) inside a `$home` based polymorph directory.

By default this points to `~/.polymorph`, and at init time it ensures that the needed structure exists

In this case, we validate:
```
- ~/.polymorph
- ~/.polymorph/conditions
- ~/.polymorph/templates
- ~/.polymorph/conditions/executions
- ~/.polymorph/conditions/postconditions
- ~/.polymorph/conditions/preconditions
```

This adapts all IO operations to ensure using new settings.paths

It also provides a new way to perform hot module loading based on the imp library, see new method `utils.import_file`

Additionally templates saving ensures that .json extension is included, and dumps the template to the templates folder `~/.polymorph/templates`.

WIP, some things to do
- [ ] validate and test using all support py versions (2.7, 3.4, 3.6, 3.7, ...)
- [ ] review pcap creation and loading
- [ ] analyze other possible IO
- [ ] test Windows, MacOS, ...
- [ ] manage lack of permisions to write on home
  - go to /tmp?

Will fix #1 